### PR TITLE
fix: add .dockerignore to reduce Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Version control metadata
+.git/
+.github/
+
+# Python bytecode, caches, and test artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.nox/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# Build and packaging artifacts
+build/
+dist/
+*.egg-info/
+.eggs/
+pip-wheel-metadata/
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+wikipedia-mcp-env/
+
+# Node and local editor artifacts
+node_modules/
+.vscode/
+.idea/
+.cursor/
+*.swp
+*.swo
+.DS_Store
+
+# Documentation build output
+docs/_build/
+site/


### PR DESCRIPTION
## Summary
Added `.dockerignore` to reduce Docker build context and avoid accidental artifact inclusion.

## Changes
- Added `.dockerignore` excluding VCS metadata, virtualenvs, Python caches/test outputs, build artifacts, editor/local artifacts, node artifacts, and docs build outputs.

## Validation
- `flake8 wikipedia_mcp tests` - **Success**
- `black --check wikipedia_mcp tests` - **Success**
- `mypy wikipedia_mcp` - **Success**
- `pytest --cov=wikipedia_mcp tests/ -v --cov-report=term --cov-report=xml:coverage.xml`
  - **Result**: `175 passed, 1 skipped` - **Success** (integration test was skipped)
- `docker build --no-cache --progress=plain -t wikipedia-mcp .`
- `docker build --progress=plain -t wikipedia-mcp .`
  - **Build context evidence**: `transferring context: 3.69kB`
- **Runtime probe**:
  - `GET /mcp` without `Accept` => `406`
  - `GET /mcp` with `Accept` but no session ID => `400`

Closes #47