### PR TITLE
Fix #49: Your project is listed on Spark — claim your listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Wikipedia MCP Server
 
 [![smithery badge](https://smithery.ai/badge/@Rudra-ravi/wikipedia-mcp)](https://smithery.ai/server/@Rudra-ravi/wikipedia-mcp)
+[![Listed on Spark](https://img.shields.io/badge/Listed%20on-Spark-blue)](https://spark.entire.vc/assets/vb-wikipedia-mcp)
 
 A Model Context Protocol (MCP) server that retrieves information from Wikipedia to provide context to Large Language Models (LLMs). This tool helps AI assistants access factual information from Wikipedia to ground their responses in reliable sources.
 


### PR DESCRIPTION
Closes #49

Adds a "Listed on Spark" badge to `README.md`, linking to the project's catalog entry at `https://spark.entire.vc/assets/vb-wikipedia-mcp`.

## Changes

- **`README.md`, line 4**: Inserted a new `[![Listed on Spark](...)]` shield badge immediately after the existing Smithery badge, using the standard `shields.io` badge format with label `Listed on Spark`, color `blue`, and target URL `https://spark.entire.vc/assets/vb-wikipedia-mcp`.

## Motivation

The project has been listed on [Spark](https://spark.entire.vc), a curated catalog of MCP connectors and AI tools. Adding the badge surface-levels discoverability for users browsing the README and signals that the project is indexed on an external catalog, consistent with how the existing Smithery badge is used.

## Testing

- Verified badge renders correctly by previewing `README.md` on GitHub — shield loads from `img.shields.io` and hyperlink resolves to `https://spark.entire.vc/assets/vb-wikipedia-mcp`.
- Confirmed no other files were modified and existing badge layout is preserved (Smithery badge remains on its own line above the new one).

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*